### PR TITLE
Add missing dependency for a running task

### DIFF
--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -94,6 +94,7 @@ def parse(blob, **depends_on):
     return output.blob
 
 
+@shaorma('email.msg_to_eml')
 def msg_to_eml(blob):
     with tempfile.TemporaryDirectory() as temp_dir:
         msg_path = Path(temp_dir) / 'email.msg'

--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -94,7 +94,7 @@ def parse(blob, **depends_on):
     return output.blob
 
 
-def msg_blob_to_eml(blob):
+def msg_to_eml(blob):
     with tempfile.TemporaryDirectory() as temp_dir:
         msg_path = Path(temp_dir) / 'email.msg'
         msg_path.symlink_to(blob.path())
@@ -110,4 +110,3 @@ def msg_blob_to_eml(blob):
             raise ShaormaError("msgconvert failed", e.output.decode('latin1'))
 
         return models.Blob.create_from_file(eml_path)
-

--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from collections import defaultdict
 import email
 from .. import models
-from ..tasks import shaorma, ShaormaError
+from ..tasks import shaorma, ShaormaError, MissingDependency
 from . import tika
 
 BYTE_ORDER_MARK = b'\xef\xbb\xbf'
@@ -29,7 +29,7 @@ def get_headers(message):
     return dict(rv)
 
 
-def dump_part(message):
+def dump_part(message, depends_on):
     rv = {'headers': get_headers(message)}
 
     content_type = message.get_content_type()
@@ -42,13 +42,21 @@ def dump_part(message):
         payload_bytes = message.get_payload(decode=True)
         with models.Blob.create() as writer:
             writer.write(payload_bytes)
-        rmeta_blob = tika.rmeta(writer.blob)
+
+        tika_key = f'tika-html-{writer.blob.pk}'
+        rmeta_blob = depends_on.get(tika_key)
+        if not rmeta_blob:
+            raise MissingDependency(tika_key, tika.rmeta.laterz(writer.blob))
+
         with rmeta_blob.open(encoding='utf8') as f:
             rmeta_data = json.load(f)
         rv['text'] = rmeta_data[0]['X-TIKA:content']
 
     if message.is_multipart():
-        rv['parts'] = [dump_part(part) for part in message.get_payload()]
+        rv['parts'] = [
+            dump_part(part, depends_on)
+            for part in message.get_payload()
+        ]
 
     if message.get_content_disposition():
         raw_filename = message.get_filename()
@@ -70,7 +78,7 @@ def dump_part(message):
 
 
 @shaorma('email.parse')
-def parse(blob):
+def parse(blob, **depends_on):
     with blob.open() as f:
         message_bytes = f.read()
 
@@ -78,7 +86,7 @@ def parse(blob):
         message_bytes = message_bytes[3:]
 
     message = email.message_from_bytes(message_bytes)
-    data = dump_part(message)
+    data = dump_part(message, depends_on)
 
     with models.Blob.create() as output:
         output.write(json.dumps(data, indent=2).encode('utf8'))

--- a/snoop/data/analyzers/emlx.py
+++ b/snoop/data/analyzers/emlx.py
@@ -1,10 +1,13 @@
 import re
 import email
 from .. import models
+from ..tasks import shaorma
 from .email import iter_parts
 
 
-def reconstruct(file):
+@shaorma('emlx.reconstruct')
+def reconstruct(file_pk):
+    file = models.File.objects.get(pk=file_pk)
     with file.original.open() as f:
         original_data = f.read()
 

--- a/snoop/data/filesystem.py
+++ b/snoop/data/filesystem.py
@@ -76,7 +76,7 @@ def handle_file(file_pk):
         )
 
     elif file.original.mime_type == "application/vnd.ms-outlook":
-        file.blob = email.msg_blob_to_eml(file.original)
+        file.blob = email.msg_to_eml(file.original)
 
     elif file.original.mime_type == 'message/x-emlx':
         file.blob = emlx.reconstruct(file)

--- a/snoop/data/filesystem.py
+++ b/snoop/data/filesystem.py
@@ -83,7 +83,11 @@ def handle_file(file_pk, **depends_on):
         file.blob = eml
 
     elif file.original.mime_type == 'message/x-emlx':
-        file.blob = emlx.reconstruct(file)
+        eml = depends_on.get('emlx_reconstruct')
+        if not eml:
+            task = emlx.reconstruct.laterz(file.pk)
+            raise MissingDependency('emlx_reconstruct', task)
+        file.blob = eml
 
     if file.blob.mime_type == 'message/rfc822':
         email_parse_task = email.parse.laterz(file.blob)

--- a/snoop/data/filesystem.py
+++ b/snoop/data/filesystem.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from django.utils import timezone
 from .utils import time_from_unix
 from . import models
-from .tasks import shaorma
+from .tasks import shaorma, MissingDependency
 from .analyzers import archives
 from .analyzers import emlx
 from .analyzers import email
@@ -64,7 +64,7 @@ def file_to_blob(directory, name):
 
 
 @shaorma('filesystem.handle_file')
-def handle_file(file_pk):
+def handle_file(file_pk, **depends_on):
     file = models.File.objects.get(pk=file_pk)
     file.blob = file.original
 
@@ -76,7 +76,11 @@ def handle_file(file_pk):
         )
 
     elif file.original.mime_type == "application/vnd.ms-outlook":
-        file.blob = email.msg_to_eml(file.original)
+        eml = depends_on.get('msg_to_eml')
+        if not eml:
+            task = email.msg_to_eml.laterz(file.original)
+            raise MissingDependency('msg_to_eml', task)
+        file.blob = eml
 
     elif file.original.mime_type == 'message/x-emlx':
         file.blob = emlx.reconstruct(file)

--- a/snoop/data/models.py
+++ b/snoop/data/models.py
@@ -196,6 +196,7 @@ class Task(models.Model):
     STATUS_PENDING = 'pending'
     STATUS_SUCCESS = 'success'
     STATUS_ERROR = 'error'
+    STATUS_DEFERRED = 'deferred'
 
     func = models.CharField(max_length=1024)
     blob_arg = models.ForeignKey(Blob, null=True, on_delete=models.DO_NOTHING,

--- a/snoop/data/tasks.py
+++ b/snoop/data/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from django.utils import timezone
+from django.db import transaction
 from . import celery
 from . import models
 from .utils import run_once
@@ -28,45 +29,49 @@ def import_shaormas():
 def laterz_shaorma(task_pk):
     import_shaormas()
 
-    task = models.Task.objects.get(pk=task_pk)
+    with transaction.atomic():
+        task = models.Task.objects.select_for_update().get(pk=task_pk)
 
-    args = task.args
-    if task.blob_arg:
-        assert args[0] == task.blob_arg.pk
-        args = [task.blob_arg] + args[1:]
+        if task.status == models.Task.STATUS_SUCCESS:
+            return
 
-    kwargs = {dep.name: dep.prev.result for dep in task.prev_set.all()}
+        args = task.args
+        if task.blob_arg:
+            assert args[0] == task.blob_arg.pk
+            args = [task.blob_arg] + args[1:]
 
-    task.status = models.Task.STATUS_PENDING
-    task.date_started = timezone.now()
-    task.save()
+        kwargs = {dep.name: dep.prev.result for dep in task.prev_set.all()}
 
-    try:
-        result = shaormerie[task.func](*args, **kwargs)
+        task.status = models.Task.STATUS_PENDING
+        task.date_started = timezone.now()
+        task.save()
 
-        if result is not None:
-            assert isinstance(result, models.Blob)
-            task.result = result
+        try:
+            result = shaormerie[task.func](*args, **kwargs)
 
-        task.status = models.Task.STATUS_SUCCESS
+            if result is not None:
+                assert isinstance(result, models.Blob)
+                task.result = result
 
-    except Exception as e:
-        if isinstance(e, ShaormaError):
-            task.error = "{} ({})".format(e.args[0], e.details)
+            task.status = models.Task.STATUS_SUCCESS
+
+        except Exception as e:
+            if isinstance(e, ShaormaError):
+                task.error = "{} ({})".format(e.args[0], e.details)
+
+            else:
+                task.error = repr(e)
+
+            task.status = models.Task.STATUS_ERROR
+            task.traceback = traceback.format_exc()
+            logger.error("Shaorma %d failed: %s", task_pk, task.error)
 
         else:
-            task.error = repr(e)
+            task.error = ''
+            task.traceback = ''
 
-        task.status = models.Task.STATUS_ERROR
-        task.traceback = traceback.format_exc()
-        logger.error("Shaorma %d failed: %s", task_pk, task.error)
-
-    else:
-        task.error = ''
-        task.traceback = ''
-
-    task.date_finished = timezone.now()
-    task.save()
+        task.date_finished = timezone.now()
+        task.save()
 
     if task.status == models.Task.STATUS_SUCCESS:
         for next_dependency in task.next_set.all():

--- a/testsuite/conftest.py
+++ b/testsuite/conftest.py
@@ -1,3 +1,36 @@
 import logging
+from collections import deque
+import pytest
+from snoop.data import tasks
+from snoop.data import models
 
 logging.getLogger('celery').setLevel(logging.WARNING)
+log = logging.getLogger(__name__)
+
+
+class TaskManager:
+
+    def __init__(self):
+        self.queue = deque()
+
+    def add(self, task_pk):
+        self.queue.append(task_pk)
+
+    def run(self, limit=100):
+        count = 0
+        while self.queue:
+            count += 1
+            task_pk = self.queue.popleft()
+            task = models.Task.objects.get(pk=task_pk)
+            log.debug(f"TaskManager #{count}: {task}")
+            tasks.laterz_shaorma(task_pk)
+            if count >= limit:
+                raise RuntimeError(f"Task limit exceeded ({limit})")
+        return count
+
+
+@pytest.fixture
+def taskmanager(monkeypatch):
+    taskmanager = TaskManager()
+    monkeypatch.setattr(tasks.laterz_shaorma, 'delay', taskmanager.add)
+    return taskmanager

--- a/testsuite/test_archives.py
+++ b/testsuite/test_archives.py
@@ -57,7 +57,7 @@ JANE_DOE_PST = Path(settings.SNOOP_TESTDATA) / "data/pst/flags_jane_doe.pst"
 TAR_GZ = Path(settings.SNOOP_TESTDATA) / "data/disk-files/archives/targz-with-pdf-doc-docx.tar.gz"
 RAR = Path(settings.SNOOP_TESTDATA) / "data/disk-files/archives/rar-with-pdf-doc-docx.rar"
 
-def test_unarchive_zip():
+def test_unarchive_zip(taskmanager):
     zip_blob = models.Blob.create_from_file(JERRY_ZIP)
     listing_blob = archives.unarchive(zip_blob)
     with listing_blob.open() as f:
@@ -71,7 +71,7 @@ def test_unarchive_zip():
     assert MOUSE_DIR in listing[0]['children']
 
 
-def test_unarchive_pst():
+def test_unarchive_pst(taskmanager):
     pst_blob = models.Blob.create_from_file(JANE_DOE_PST)
     listing_blob = archives.unarchive(pst_blob)
     with listing_blob.open() as f:
@@ -89,7 +89,7 @@ def test_unarchive_pst():
     assert len(root_dir['children']) == 3
 
 
-def test_unarchive_tar_gz():
+def test_unarchive_tar_gz(taskmanager):
     tar_gz_blob = models.Blob.create_from_file(TAR_GZ)
     listing_blob = archives.unarchive(tar_gz_blob)
     with listing_blob.open() as f:
@@ -110,7 +110,7 @@ def test_unarchive_tar_gz():
     }
 
 
-def test_unarchive_rar():
+def test_unarchive_rar(taskmanager):
     rar = models.Blob.create_from_file(RAR)
     listing_blob = archives.unarchive(rar)
     with listing_blob.open() as f:
@@ -123,7 +123,7 @@ def test_unarchive_rar():
     }
 
 
-def test_create_archive_files():
+def test_create_archive_files(taskmanager):
     zip_blob = models.Blob.create_from_file(ZIP_DOCX)
     listing_blob = archives.unarchive(zip_blob)
 

--- a/testsuite/test_emails.py
+++ b/testsuite/test_emails.py
@@ -31,7 +31,7 @@ def mock_collection():
 
 def test_convert_msg_to_eml():
     msg_blob = models.Blob.create_from_file(MSG)
-    eml_blob = email.msg_blob_to_eml(msg_blob)
+    eml_blob = email.msg_to_eml(msg_blob)
 
     assert eml_blob.mime_type == 'message/rfc822'
 

--- a/testsuite/test_integration.py
+++ b/testsuite/test_integration.py
@@ -20,7 +20,7 @@ ID = {
 }
 
 
-def test_walk_and_api(client):
+def test_walk_and_api(client, taskmanager):
     col = models.Collection.objects.create(
         name='testdata',
         root=Path(settings.SNOOP_TESTDATA) / 'data',
@@ -28,6 +28,7 @@ def test_walk_and_api(client):
     root = col.directory_set.create()
 
     dispatcher.run_dispatcher()
+    taskmanager.run(limit=10000)
 
     col_url = '/collections/testdata/json'
     col = client.get(col_url).json()

--- a/testsuite/test_shaorma.py
+++ b/testsuite/test_shaorma.py
@@ -5,7 +5,7 @@ from snoop.data import models
 pytestmark = [pytest.mark.django_db]
 
 
-def test_dependent_task():
+def test_dependent_task(taskmanager):
     @shaorma('test_one')
     def one():
         with models.Blob.create() as writer:
@@ -19,12 +19,15 @@ def test_dependent_task():
 
     one_task = one.laterz()
     two_task = two.laterz(depends_on={'one_result': one_task})
+
+    taskmanager.run()
+
     two_task.refresh_from_db()
     with two_task.result.open() as f:
         assert f.read() == b'foo'
 
 
-def test_blob_arg():
+def test_blob_arg(taskmanager):
     @shaorma('test_with_blob')
     def with_blob(blob, a):
         with blob.open(encoding='utf8') as src:
@@ -40,6 +43,8 @@ def test_blob_arg():
 
     task = with_blob.laterz(writer.blob, 'world')
     assert task.blob_arg == writer.blob
+
+    taskmanager.run()
 
     task.refresh_from_db()
     with task.result.open() as f:


### PR DESCRIPTION
A task gets the ability to say "hey, I need this task to run before I can finish my work". It aborts execution, gets marked with state "pending", and the new task gets added to its `depends_on` list.

I've used this mechanism to shaormify email html-to-text processing, conversion from msg to eml, and reconstructing an emlx from parts. Maybe this is a good way to allow emlx reconstruction to wait for dependent files to be imported as blobs.

