### PR TITLE
Locations, bleach, word count

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,4 @@ psycopg2
 requests
 waitress
 whitenoise
+bleach

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,14 @@
 amqp==2.2.2               # via kombu
 attrs==17.4.0             # via pytest
 billiard==3.5.0.3         # via celery
+bleach==2.1.2
 celery==4.1.0
 certifi==2017.11.5        # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 django==2.0
 first==2.0.1              # via pip-tools
+html5lib==1.0.1           # via bleach
 idna==2.6                 # via requests
 kombu==4.1.0              # via celery
 pip-tools==1.11.0
@@ -23,8 +25,9 @@ pytest-django==3.1.2
 pytest==3.3.2
 pytz==2017.3              # via celery, django
 requests==2.18.4
-six==1.11.0               # via pip-tools, pytest
+six==1.11.0               # via bleach, html5lib, pip-tools, pytest
 urllib3==1.22             # via requests
 vine==1.1.4               # via amqp
 waitress==1.1.0
+webencodings==0.5.1       # via html5lib
 whitenoise==3.3.1

--- a/snoop/data/analyzers/html.py
+++ b/snoop/data/analyzers/html.py
@@ -1,0 +1,23 @@
+import bleach
+
+ALLOWED_TAGS = list(bleach.ALLOWED_TAGS)
+ALLOWED_TAGS.remove('a')
+
+
+def is_html(blob):
+    [main_type, subtype] = blob.mime_type.split('/')
+
+    if main_type in ['text', 'application']:
+        if (subtype.startswith('html') or
+            subtype.startswith('xhtml') or
+            subtype.startswith('xml')):
+            return True
+
+    return False
+
+
+def clean(blob):
+    with blob.open(encoding=blob.mime_encoding) as f:
+        html = f.read()
+
+    return bleach.clean(html, strip=True, tags=ALLOWED_TAGS)

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -188,9 +188,11 @@ def child_dir_to_dict(directory):
 
 
 def get_directory_children(directory):
+    child_directory_queryset = directory.child_directory_set.order_by('name')
+    child_file_queryset = directory.child_file_set.order_by('name')
     return (
-        [child_dir_to_dict(d) for d in directory.child_directory_set.all()] +
-        [child_file_to_dict(f) for f in directory.child_file_set.all()]
+        [child_dir_to_dict(d) for d in child_directory_queryset] +
+        [child_file_to_dict(f) for f in child_file_queryset]
     )
 
 

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -134,22 +134,25 @@ def get_document_data(digest):
         'path': full_path(first_file),
     }
 
+    children = None
+
+    if blob.mime_type == 'message/rfc822':
+        content.update(email_meta(digest_data))
+
+        attachments = first_file.child_directory_set.first()
+        if attachments:
+            children = [
+                child_file_to_dict(f)
+                for f in attachments.child_file_set.order_by('pk').all()
+            ]
+
     rv = {
         'id': blob.pk,
         'parent_id': parent_id(first_file),
         'version': zulu(digest.date_modified),
         'content': content,
+        'children': children,
     }
-
-    if blob.mime_type == 'message/rfc822':
-        rv['content'].update(email_meta(digest_data))
-
-        attachments = first_file.child_directory_set.first()
-        if attachments:
-            rv['children'] = [
-                child_file_to_dict(f)
-                for f in attachments.child_file_set.order_by('pk').all()
-            ]
 
     return rv
 

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -160,6 +160,19 @@ def get_document_data(digest):
     return rv
 
 
+def get_document_locations(digest):
+    def location(file):
+        parent = file.parent_directory
+        return {
+            'filename': file.name,
+            'parent_id': directory_id(parent),
+            'parent_path': full_path(parent),
+        }
+
+    queryset = digest.blob.file_set.order_by('pk')
+    return [location(file) for file in queryset]
+
+
 def child_file_to_dict(file):
     blob = file.blob
     return {

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -134,17 +134,13 @@ def get_document_data(digest):
         'path': full_path(first_file),
     }
 
-    children = None
-
     if blob.mime_type == 'message/rfc822':
         content.update(email_meta(digest_data))
 
-        attachments = first_file.child_directory_set.first()
-        if attachments:
-            children = [
-                child_file_to_dict(f)
-                for f in attachments.child_file_set.order_by('pk').all()
-            ]
+    children = None
+    child_directory = first_file.child_directory_set.first()
+    if child_directory:
+        children = get_directory_children(child_directory)
 
     text = content.get('text') or ""
     content['word-count'] = len(text.strip().split())
@@ -191,12 +187,14 @@ def child_dir_to_dict(directory):
     }
 
 
-def get_directory_data(directory):
-    children = (
+def get_directory_children(directory):
+    return (
         [child_dir_to_dict(d) for d in directory.child_directory_set.all()] +
         [child_file_to_dict(f) for f in directory.child_file_set.all()]
     )
 
+
+def get_directory_data(directory):
     return {
         'id': directory_id(directory),
         'parent_id': parent_id(directory),
@@ -206,5 +204,5 @@ def get_directory_data(directory):
             'filename': directory.name,
             'path': full_path(directory),
         },
-        'children': children,
+        'children': get_directory_children(directory),
     }

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -146,6 +146,9 @@ def get_document_data(digest):
                 for f in attachments.child_file_set.order_by('pk').all()
             ]
 
+    text = content.get('text') or ""
+    content['word-count'] = len(text.strip().split())
+
     rv = {
         'id': blob.pk,
         'parent_id': parent_id(first_file),

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -152,6 +152,7 @@ def get_document_data(digest):
     rv = {
         'id': blob.pk,
         'parent_id': parent_id(first_file),
+        'has_locations': True,
         'version': zulu(digest.date_modified),
         'content': content,
         'children': children,

--- a/snoop/data/dispatcher.py
+++ b/snoop/data/dispatcher.py
@@ -9,11 +9,7 @@ logger = logging.getLogger(__name__)
 
 def dispatch_walk_tasks():
     for collection in models.Collection.objects.all():
-        [root] = collection.directory_set.filter(
-            parent_directory__isnull=True,
-            container_file__isnull=True
-        ).all()
-        walk.laterz(root.pk)
+        walk.laterz(collection.root_directory.pk)
 
 
 def run_dispatcher():

--- a/snoop/data/models.py
+++ b/snoop/data/models.py
@@ -142,6 +142,13 @@ class Collection(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def root_directory(self):
+        return self.directory_set.filter(
+            parent_directory__isnull=True,
+            container_file__isnull=True
+        ).first()
+
 
 class Directory(models.Model):
     collection = models.ForeignKey(Collection, on_delete=models.DO_NOTHING)

--- a/snoop/data/models.py
+++ b/snoop/data/models.py
@@ -116,6 +116,13 @@ class Blob(models.Model):
         writer.blob = blob
 
     @classmethod
+    def create_from_bytes(cls, data):
+        with cls.create() as writer:
+            writer.write(data)
+
+        return writer.blob
+
+    @classmethod
     def create_from_file(cls, path):
         with cls.create() as writer:
             with open(path, 'rb') as f:

--- a/snoop/data/urls.py
+++ b/snoop/data/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('<name>/_directory_<int:pk>/json', views.directory),
     path('<name>/<hash>/json', views.document),
     path('<name>/<hash>/raw/<filename>', views.document_download),
+    path('<name>/<hash>/locations', views.document_locations),
 ]

--- a/snoop/data/views.py
+++ b/snoop/data/views.py
@@ -65,3 +65,10 @@ def document_download(request, name, hash, filename):
         return HttpResponse(clean_html, content_type='text/html')
 
     return FileResponse(digest.blob.open(), content_type=blob.content_type)
+
+
+def document_locations(request, name, hash):
+    collection = get_object_or_404(models.Collection.objects, name=name)
+    digest = get_object_or_404(collection.digest_set, blob__pk=hash)
+    locations = digests.get_document_locations(digest)
+    return JsonResponse({'locations': locations})

--- a/snoop/data/views.py
+++ b/snoop/data/views.py
@@ -1,9 +1,10 @@
 import json
-from django.http import JsonResponse, FileResponse
+from django.http import HttpResponse, JsonResponse, FileResponse
 from django.shortcuts import get_object_or_404
 from django.conf import settings
 from . import models
 from . import digests
+from .analyzers import html
 
 
 def collection(request, name):
@@ -59,7 +60,8 @@ def document_download(request, name, hash, filename):
     digest = get_object_or_404(collection.digest_set, blob__pk=hash)
     blob = digest.blob
 
-    if blob.mime_type == 'text/html':
-        raise NotImplementedError
+    if html.is_html(blob):
+        clean_html = html.clean(blob)
+        return HttpResponse(clean_html, content_type='text/html')
 
     return FileResponse(digest.blob.open(), content_type=blob.content_type)

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -1,0 +1,90 @@
+import pytest
+from django.utils import timezone
+from snoop.data import models
+from snoop.data import filesystem
+
+pytestmark = [pytest.mark.django_db]
+
+
+class FakeData:
+
+    def collection(self, name='testdata'):
+        collection = models.Collection.objects.create(name=name, root='')
+        collection.directory_set.create()
+        return collection
+
+    def blob(self, data):
+        return models.Blob.create_from_bytes(data)
+
+    def directory(self, parent, name):
+        directory = models.Directory.objects.create(
+            collection=parent.collection,
+            parent_directory=parent,
+            name=name,
+        )
+        return directory
+
+    def file(self, parent, name, blob):
+        now = timezone.now()
+        file = models.File.objects.create(
+            collection=parent.collection,
+            parent_directory=parent,
+            name=name,
+            ctime=now,
+            mtime=now,
+            size=blob.size,
+            original=blob,
+            blob=blob,
+        )
+        filesystem.handle_file.laterz(file.pk)
+        return file
+
+
+class CollectionApiClient:
+
+    def __init__(self, collection, client):
+        self.collection = collection
+        self.client = client
+
+    def get(self, url):
+        url = f'/collections/{self.collection.name}{url}'
+        resp = self.client.get(url)
+        assert resp.status_code == 200
+        return resp.json()
+
+    def get_locations(self, blob_hash):
+        return self.get(f'/{blob_hash}/locations')
+
+
+@pytest.fixture
+def fakedata():
+    return FakeData()
+
+
+def test_blob_locations(client, fakedata, taskmanager):
+    collection = fakedata.collection()
+    dir1 = fakedata.directory(collection.root_directory, 'dir1')
+    dir2 = fakedata.directory(collection.root_directory, 'dir2')
+    blob = fakedata.blob(b'hello world')
+    fakedata.file(dir1, 'foo', blob)
+    fakedata.file(dir2, 'bar', blob)
+
+    taskmanager.run()
+
+    def directory_id(directory):
+        return f'_directory_{directory.pk}'
+
+    api = CollectionApiClient(collection, client)
+    resp = api.get_locations(blob.pk)
+    assert resp['locations'] == [
+        {
+            'filename': 'foo',
+            'parent_id': directory_id(dir1),
+            'parent_path': '/dir1',
+        },
+        {
+            'filename': 'bar',
+            'parent_id': directory_id(dir2),
+            'parent_path': '/dir2',
+        },
+    ]

--- a/testsuite/test_emails.py
+++ b/testsuite/test_emails.py
@@ -160,9 +160,9 @@ def test_double_decoding_of_attachment_filenames(taskmanager):
 def test_attachment_with_octet_stream_content_type(taskmanager):
     data = parse_email(OCTET_STREAM_CONTENT_TYPE, taskmanager)
 
-    assert data['children'][0]['content_type'] == 'application/msword'
-    assert data['children'][1]['content_type'] == 'application/zip'
-    assert data['children'][2]['content_type'] == 'image/png'
+    assert data['children'][0]['content_type'] == 'image/png'
+    assert data['children'][1]['content_type'] == 'application/msword'
+    assert data['children'][2]['content_type'] == 'application/zip'
 
 
 def test_broken_header():


### PR DESCRIPTION
Three features rolled into a single PR:

* Clean HTML using the `bleach` library (fixes https://github.com/hoover/snoop2/issues/3)
* Provide a list of locations where a blob appears in the filesystem, check out https://github.com/hoover/ui/pull/17 for how it's used
* Count words in a document - the number is displayed in the search results
* If a file has a child directory, return its children
