### PR TITLE
PGP emails

### DIFF
--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -7,6 +7,7 @@ import email
 from .. import models
 from ..tasks import shaorma, ShaormaError, require_dependency
 from . import tika
+from . import pgp
 
 BYTE_ORDER_MARK = b'\xef\xbb\xbf'
 
@@ -51,6 +52,10 @@ def dump_part(message, depends_on):
 
     content_type = message.get_content_type()
     payload_bytes = message.get_payload(decode=True)
+
+    if pgp.is_encrypted(payload_bytes):
+        payload_bytes = pgp.decrypt(payload_bytes)
+        rv['pgp'] = True
 
     if content_type == 'text/plain':
         charset = message.get_content_charset() or 'latin1'

--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -42,6 +42,13 @@ def get_headers(message):
 def dump_part(message, depends_on):
     rv = {'headers': get_headers(message)}
 
+    if message.is_multipart():
+        rv['parts'] = [
+            dump_part(part, depends_on)
+            for part in message.get_payload()
+        ]
+        return rv
+
     content_type = message.get_content_type()
     if content_type == 'text/plain':
         payload_bytes = message.get_payload(decode=True)
@@ -61,12 +68,6 @@ def dump_part(message, depends_on):
         with rmeta_blob.open(encoding='utf8') as f:
             rmeta_data = json.load(f)
         rv['text'] = rmeta_data[0].get('X-TIKA:content', "")
-
-    if message.is_multipart():
-        rv['parts'] = [
-            dump_part(part, depends_on)
-            for part in message.get_payload()
-        ]
 
     if message.get_content_disposition():
         raw_filename = message.get_filename()

--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -50,13 +50,13 @@ def dump_part(message, depends_on):
         return rv
 
     content_type = message.get_content_type()
+    payload_bytes = message.get_payload(decode=True)
+
     if content_type == 'text/plain':
-        payload_bytes = message.get_payload(decode=True)
         charset = message.get_content_charset() or 'latin1'
         rv['text'] = payload_bytes.decode(charset, errors='replace')
 
     if content_type == 'text/html':
-        payload_bytes = message.get_payload(decode=True)
         with models.Blob.create() as writer:
             writer.write(payload_bytes)
 
@@ -73,10 +73,9 @@ def dump_part(message, depends_on):
         raw_filename = message.get_filename()
         if raw_filename:
             filename = read_header(raw_filename)
-            attachment_content = message.get_payload(decode=True)
 
             with models.Blob.create() as writer:
-                writer.write(attachment_content)
+                writer.write(payload_bytes)
 
             rv['attachment'] = {
                 'name': filename,

--- a/snoop/data/analyzers/pgp.py
+++ b/snoop/data/analyzers/pgp.py
@@ -1,0 +1,28 @@
+import subprocess
+from django.conf import settings
+from ..tasks import ShaormaBroken
+
+
+def is_encrypted(data):
+    return b'-----BEGIN PGP MESSAGE-----' in data
+
+
+def decrypt(data):
+    if not settings.SNOOP_GNUPG_HOME:
+        raise ShaormaBroken("No SNOOP_GNUPG_HOME set", 'gpg_not_configured')
+
+    result = subprocess.run(
+        ['gpg', '--home', settings.SNOOP_GNUPG_HOME, '--decrypt'],
+        input=data,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def import_keys(keydata):
+    subprocess.run(
+        ['gpg', '--home', settings.SNOOP_GNUPG_HOME, '--import'],
+        input=keydata,
+        check=True,
+    )

--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -110,10 +110,14 @@ def email_meta(digest_data):
     headers = email_data['headers']
 
     text_bits = []
+    pgp = False
     for part in iter_parts(email_data):
         part_text = part.get('text')
         if part_text:
             text_bits.append(part_text)
+
+        if part.get('pgp'):
+            pgp = True
 
     headers_to = set()
     for header in ['To', 'Cc', 'Bcc', 'Resent-To', 'Recent-Cc']:
@@ -124,6 +128,7 @@ def email_meta(digest_data):
         'to': list(headers_to),
         'subject': headers.get('Subject', [''])[0],
         'text': '\n\n'.join(text_bits).strip(),
+        'pgp': pgp,
     }
 
 
@@ -137,6 +142,7 @@ def get_document_data(digest):
         'content-type': blob.mime_type,
         'filetype': filetype(blob.mime_type),
         'text': digest_data.get('text'),
+        'pgp': digest_data.get('pgp'),
         'ocr': digest_data.get('ocr'),
         'ocrtext': digest_data.get('ocrtext'),
         'md5': blob.md5,

--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -64,6 +64,7 @@ STATIC_ROOT = str(base_dir / 'static')
 
 SNOOP_BLOB_STORAGE = str(base_dir / 'blobs')
 SNOOP_TIKA_URL = 'http://localhost:9998'
+SNOOP_GNUPG_HOME = None
 SNOOP_FEED_PAGE_SIZE = 100
 SNOOP_ELASTICSEARCH_URL = None
 SNOOP_ELASTICSEARCH_INDEX_PREFIX = 'snoop2-'

--- a/testsuite/test_pgp.py
+++ b/testsuite/test_pgp.py
@@ -1,0 +1,58 @@
+import json
+import tempfile
+from pathlib import Path
+import pytest
+from django.conf import settings
+from snoop.data import models
+from snoop.data import tasks
+from snoop.data.analyzers import email
+from snoop.data.analyzers import pgp
+
+PATH_HUSH_MAIL = 'eml-9-pgp/encrypted-hushmail-knockoff.eml'
+HEIN_PRIVATE_KEY = 'eml-9-pgp/keys/hein-priv.gpg'
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture()
+def configure_gpg(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setattr(settings, 'SNOOP_GNUPG_HOME', tmp)
+        path = Path(settings.SNOOP_TESTDATA) / 'data' / HEIN_PRIVATE_KEY
+        with path.open('rb') as f:
+            pgp.import_keys(f.read())
+
+        yield
+
+
+@pytest.fixture()
+def gpg_blob():
+    path = Path(settings.SNOOP_TESTDATA) / 'data' / PATH_HUSH_MAIL
+    return models.Blob.create_from_file(path)
+
+
+def test_decrypted_data(gpg_blob, configure_gpg):
+    parsed_blob = email.parse(gpg_blob)
+
+    with parsed_blob.open(encoding='utf8') as f:
+        data = json.load(f)
+
+    assert data['headers']['Subject'][0] == "Fwd: test email"
+    assert data['headers']['Date'][0] == 'Wed, 10 Aug 2016 15:00:00 -0000'
+
+    assert data['parts'][0]['pgp']
+    text = data['parts'][0]['text']
+    assert "This is GPG v1 speaking!" in text
+    assert "Hello from the other side!" in text
+    assert "Sent from my Android piece of !@#%." in text
+
+    word_doc_pk = data['parts'][3]['attachment']['blob_pk']
+    word_doc = models.Blob.objects.get(pk=word_doc_pk)
+    assert word_doc.mime_type == 'application/msword'
+
+
+def test_broken_if_no_gpg_home(gpg_blob):
+    with pytest.raises(tasks.ShaormaBroken) as e:
+        email.parse(gpg_blob)
+
+    assert e.value.reason == 'gpg_not_configured'


### PR DESCRIPTION
Unlike the original snoop implementation, this does not use python-gnupg, because it barfs when trying to import the keys in testdata. And it's so easy to call gpg directly.
