### PR TITLE
Some msg files are detected as `application/vnd.ms-outlook`

### DIFF
--- a/snoop/data/analyzers/email.py
+++ b/snoop/data/analyzers/email.py
@@ -13,7 +13,12 @@ from . import pgp
 
 BYTE_ORDER_MARK = b'\xef\xbb\xbf'
 
-log= logging.getLogger(__name__)
+OUTLOOK_POSSIBLE_MIME_TYPES = [
+    'application/vnd.ms-outlook',
+    'application/vnd.ms-office',
+]
+
+log = logging.getLogger(__name__)
 
 
 def iter_parts(message, numbers=[]):

--- a/snoop/data/filesystem.py
+++ b/snoop/data/filesystem.py
@@ -82,11 +82,14 @@ def handle_file(file_pk, **depends_on):
             depends_on={'archive_listing': unarchive_task},
         )
 
-    elif file.original.mime_type == "application/vnd.ms-outlook":
-        file.blob = require_dependency(
-            'msg_to_eml', depends_on,
-            lambda: email.msg_to_eml.laterz(file.original),
-        )
+    elif file.original.mime_type in email.OUTLOOK_POSSIBLE_MIME_TYPES:
+        try:
+            file.blob = require_dependency(
+                'msg_to_eml', depends_on,
+                lambda: email.msg_to_eml.laterz(file.original),
+            )
+        except ShaormaBroken:
+            pass
 
     elif file.original.mime_type == 'message/x-emlx':
         file.blob = require_dependency(


### PR DESCRIPTION
The idea is to attempt conversion to eml and gracefully move on if it fails. Tested locally with a msg file, but I can't add it to testdata.
