### PR TITLE
Index original content-type, hashes and size

### DIFF
--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -206,8 +206,10 @@ def _get_document_content(digest):
         if first_file.child_directory_set.count() > 0:
             attachments = True
 
+    original = first_file.original
+
     content = {
-        'content-type': digest.blob.mime_type,
+        'content-type': original.mime_type,
         'filetype': filetype,
         'text': digest_data.get('text'),
         'pgp': digest_data.get('pgp'),
@@ -215,9 +217,9 @@ def _get_document_content(digest):
         'ocrtext': digest_data.get('ocrtext'),
         'date': digest_data.get('date'),
         'date-created': digest_data.get('date-created'),
-        'md5': digest.blob.md5,
-        'sha1': digest.blob.sha1,
-        'size': digest.blob.size,
+        'md5': original.md5,
+        'sha1': original.sha1,
+        'size': original.size,
         'filename': first_file.name,
         'path': full_path(first_file),
         'broken': digest_data.get('broken'),

--- a/testsuite/test_digest.py
+++ b/testsuite/test_digest.py
@@ -21,3 +21,24 @@ def test_digest_with_broken_dependency(fakedata, taskmanager, client):
     assert digest['size'] == 1000
     assert digest['text'] is None
     assert digest['broken'] == ['tika_http_422']
+
+
+def test_digest_msg(fakedata, taskmanager, client):
+    collection = fakedata.collection()
+    msg = TESTDATA / 'msg-5-outlook/DISEARĂ-Te-așteptăm-la-discuția-despre-finanțarea-culturii.msg'
+    with msg.open('rb') as f:
+        blob = fakedata.blob(f.read())
+    msg_file = fakedata.file(collection.root_directory, 'the.msg', blob)
+
+    taskmanager.run()
+
+    msg_file.refresh_from_db()
+    api = CollectionApiClient(collection, client)
+    digest = api.get_digest(msg_file.blob.pk)['content']
+
+    assert digest['content-type'] == 'application/vnd.ms-outlook'
+    assert digest['filename'] == 'the.msg'
+    assert digest['filetype'] == 'email'
+    assert digest['md5'] == '38385c4487719fa9dd0fb695d3aad0ee'
+    assert digest['sha1'] == '90548132e18bfc3088e81918bbcaf887a68c6acc'
+    assert digest['size'] == 19968


### PR DESCRIPTION
For converted msg and emlx emails, the digest contains the hashes of the converted email, not the original. This makes it impossible to trace the original file across tools.

This patch changes digest to use the hashes, content-type and size from the original blob. The pk still comes from the converted message though; changing that will be more difficult.
