### PR TITLE
fix(search): Increase from 10 000 to 20 000 the maximum numbers of re…

### DIFF
--- a/snoop/data/indexing.py
+++ b/snoop/data/indexing.py
@@ -47,6 +47,9 @@ SETTINGS = {
                 "filter": ["standard", "lowercase", "asciifolding"],
             }
         }
+    },
+    "index": {
+        "max_result_window": "20000"
     }
 }
 


### PR DESCRIPTION
…sults returned by es (max_result_window)
>>
The max_result_window will be set for all new indexes. For new indexes
it can be set with the following request:
```

curl -X PUT "localhost:9200/testdata/_settings" -H 'Content-Type:
application/json' -d'
{
    "index" : {
        "max_result_window" : 30000
    }
}
'

```
I created also a version that uses search_after
(see: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-
request-search-after.html)
This version(with search_after) can be used when the search es will be migrated to version
5+ (currently es version is 2.4.6)