### PR TITLE
fix(docker): Prevent using python 3.7 until kombu supports it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-stretch
+FROM python:3.6-stretch
 ENV PYTHONUNBUFFERED 1
 
 RUN set -e \


### PR DESCRIPTION
See: https://github.com/celery/kombu/issues/841