### PR TITLE
Try using a requests Session for Tika calls.

### DIFF
--- a/snoop/data/analyzers/tika.py
+++ b/snoop/data/analyzers/tika.py
@@ -45,17 +45,17 @@ TIKA_CONTENT_TYPES = [
     'application/vnd.oasis.opendocument.presentation-template',
 ]
 
-
 def can_process(blob):
     if blob.mime_type in TIKA_CONTENT_TYPES:
         return True
 
     return False
 
+session = requests.Session()
 
 def call_tika_server(endpoint, data):
     url = urljoin(settings.SNOOP_TIKA_URL, endpoint)
-    resp = requests.put(url, data=data)
+    resp = session.put(url, data=data)
 
     if resp.status_code == 422:
         raise ShaormaBroken("tika returned http 422, corrupt?", "tika_http_422")


### PR DESCRIPTION
This should give us Keep-Alive connections for Tika calls, which could be a significant performance benefit:

http://docs.python-requests.org/en/master/user/advanced/#keep-alive