### PR TITLE
Hoover - index path as text not only as keyword

### DIFF
--- a/snoop/data/digests.py
+++ b/snoop/data/digests.py
@@ -267,6 +267,7 @@ def _get_document_content(digest):
         'size': original.size,
         'filename': first_file.name,
         'path': path,
+        'path-text': path,
         'path-parts': path_parts(path),
         'broken': digest_data.get('broken'),
         'attachments': attachments,

--- a/snoop/data/indexing.py
+++ b/snoop/data/indexing.py
@@ -35,6 +35,7 @@ MAPPINGS = {
             "message": {"type": "keyword"},
             "message-id": {"type": "keyword"},
             "path": {"type": "keyword"},
+            "path-text": {"type": "text"},
             "path-parts": {"type": "keyword"},
             "references": {"type": "keyword"},
             "rev": {"type": "integer"},


### PR DESCRIPTION
Updated code to also index the path as text.
The reindex part seems to be doable from the snoop2 management commands.