### PR TITLE
Use `gpghome` folder which is already set up

### DIFF
--- a/snoop/data/analyzers/pgp.py
+++ b/snoop/data/analyzers/pgp.py
@@ -1,6 +1,9 @@
+from pathlib import Path
 import subprocess
 from django.conf import settings
 from ..tasks import ShaormaBroken
+
+gpghome = Path(settings.SNOOP_COLLECTION_ROOT).parent / 'gpghome'
 
 
 def is_encrypted(data):
@@ -8,11 +11,11 @@ def is_encrypted(data):
 
 
 def decrypt(data):
-    if not settings.SNOOP_GNUPG_HOME:
-        raise ShaormaBroken("No SNOOP_GNUPG_HOME set", 'gpg_not_configured')
+    if not gpghome.exists():
+        raise ShaormaBroken("No gpghome folder", 'gpg_not_configured')
 
     result = subprocess.run(
-        ['gpg', '--home', settings.SNOOP_GNUPG_HOME, '--decrypt'],
+        ['gpg', '--home', gpghome, '--decrypt'],
         input=data,
         check=True,
         stdout=subprocess.PIPE,
@@ -22,7 +25,7 @@ def decrypt(data):
 
 def import_keys(keydata):
     subprocess.run(
-        ['gpg', '--home', settings.SNOOP_GNUPG_HOME, '--import'],
+        ['gpg', '--home', gpghome, '--import'],
         input=keydata,
         check=True,
     )

--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -95,7 +95,6 @@ SNOOP_COLLECTIONS_ELASTICSEARCH_URL = os.environ.get('SNOOP_ES_URL', 'http://loc
 
 SNOOP_BLOB_STORAGE = str(base_dir / 'blobs')
 SNOOP_TIKA_URL = os.environ.get('SNOOP_TIKA_URL', 'http://localhost:9998')
-SNOOP_GNUPG_HOME = None
 SNOOP_FEED_PAGE_SIZE = 100
 SNOOP_COLLECTIONS_ELASTICSEARCH_INDEX = os.environ.get('SNOOP_ES_INDEX', 'snoop2')
 SNOOP_COLLECTION_ROOT = os.environ.get('SNOOP_COLLECTION_ROOT')

--- a/testsuite/snoop-settings.py
+++ b/testsuite/snoop-settings.py
@@ -30,5 +30,3 @@ if os.environ.get('DOCKER_HOOVER_SNOOP_STATS', 'on') == 'on':
     SNOOP_STATS_ELASTICSEARCH_URL = 'http://snoop-stats-es:9200'
 
 SNOOP_COLLECTIONS_ELASTICSEARCH_URL = 'http://search-es:9200'
-
-SNOOP_GNUPG_HOME = '/opt/hoover/gnupg'

--- a/testsuite/test_integration.py
+++ b/testsuite/test_integration.py
@@ -76,8 +76,10 @@ def test_complete_lifecycle(client, taskmanager):
     assert es_count == db_count
 
     # check that all index ops were successful
-    db_failed_count = models.Task.objects.filter(func='digests.index').exclude(status='success').count()
-    assert db_failed_count == 0
+    index_failed = [(t.args, t.status) for t in models.Task.objects.filter(func='digests.index').exclude(status='success')]
+    # one indexing task should be deferred because
+    # `encrypted-hushmail-smashed-bytes.eml` is broken
+    assert index_failed == [(['66a3a6bb9b8d86b7ce2be5e9f3a794a778a85fb58b8550a54b7e2821d602e1f1'], 'deferred')]
 
     # test export and import database
     with tempfile.TemporaryFile('w+b') as f:

--- a/testsuite/test_pgp.py
+++ b/testsuite/test_pgp.py
@@ -1,32 +1,17 @@
 import json
 from pathlib import Path
-import tempfile
-
 from django.conf import settings
 import pytest
 
-from fixtures import TESTDATA, CollectionApiClient
+from fixtures import CollectionApiClient
 from snoop.data import models
 from snoop.data import tasks
 from snoop.data.analyzers import email
 from snoop.data.analyzers import pgp
 
 PATH_HUSH_MAIL = 'eml-9-pgp/encrypted-hushmail-knockoff.eml'
-HEIN_PRIVATE_KEY = 'eml-9-pgp/keys/hein-priv.gpg'
 
 pytestmark = [pytest.mark.django_db]
-
-
-@pytest.fixture()
-def configure_gpg(monkeypatch):
-    tmp = tempfile.mkdtemp()  # tempfile.TemporaryDirectory cleanup() fails
-
-    monkeypatch.setattr(settings, 'SNOOP_GNUPG_HOME', tmp)
-    path = TESTDATA / HEIN_PRIVATE_KEY
-    with path.open('rb') as f:
-        pgp.import_keys(f.read())
-
-    yield
 
 
 @pytest.fixture()
@@ -35,7 +20,7 @@ def gpg_blob():
     return models.Blob.create_from_file(path)
 
 
-def test_decrypted_data(gpg_blob, configure_gpg):
+def test_decrypted_data(gpg_blob):
     parsed_blob = email.parse(gpg_blob)
 
     with parsed_blob.open(encoding='utf8') as f:
@@ -55,7 +40,7 @@ def test_decrypted_data(gpg_blob, configure_gpg):
     assert word_doc.mime_type == 'application/msword'
 
 
-def test_gpg_digest(gpg_blob, configure_gpg, client, fakedata, taskmanager):
+def test_gpg_digest(gpg_blob, client, fakedata, taskmanager):
     root = fakedata.init()
     fakedata.file(root, 'email', gpg_blob)
 
@@ -66,7 +51,9 @@ def test_gpg_digest(gpg_blob, configure_gpg, client, fakedata, taskmanager):
     assert digest['pgp']
 
 
-def test_broken_if_no_gpg_home(gpg_blob):
+def test_broken_if_no_gpg_home(gpg_blob, monkeypatch):
+    monkeypatch.setattr(pgp, 'gpghome', Path('/tmp/no-such-gpghome'))
+
     with pytest.raises(tasks.ShaormaBroken) as e:
         email.parse(gpg_blob)
 


### PR DESCRIPTION
The PGP code was always kind of a hack, and it expects a gnupg home folder to be set up. So https://github.com/hoover/testdata/commit/c7c3bee47b431c43d4bbdfa1bae720e2dfd0e6d8 creates that folder in testdata, next to `data` and `ocr`. The idea is that, if you want pgp snooping, you set up the home folder in the collection folder, and snoop will auto-detect it.