### PR TITLE
Don't run_dispatcher() on initcollection

### DIFF
--- a/snoop/data/management/commands/initcollection.py
+++ b/snoop/data/management/commands/initcollection.py
@@ -2,7 +2,6 @@ from django.core.management.base import BaseCommand
 from django.core import management
 
 from ... import indexing
-from ...dispatcher import run_dispatcher
 from ...logs import logging_for_management_command
 
 

--- a/snoop/data/management/commands/initcollection.py
+++ b/snoop/data/management/commands/initcollection.py
@@ -13,4 +13,3 @@ class Command(BaseCommand):
         logging_for_management_command(options['verbosity'])
         management.call_command('migrate')
         indexing.create_index()
-        run_dispatcher()


### PR DESCRIPTION
We already have a `rundispatcher` command for this.

Needed by https://github.com/liquidinvestigations/node/pull/148