### PR TITLE
Decrease load impact from sync

### DIFF
--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -121,11 +121,11 @@ if _tracing_url:
 celery.app.conf.beat_schedule = {
     'check_if_idle': {
         'task': 'snoop.data.tasks.check_if_idle',
-        'schedule': timedelta(seconds=60),
+        'schedule': timedelta(minutes=4),
     },
     'auto_sync': {
         'task': 'snoop.data.tasks.auto_sync',
-        'schedule': timedelta(seconds=60)
+        'schedule': timedelta(minutes=7)
     }
 }
 


### PR DESCRIPTION
We could add some `sleep 100ms` instructions in between the auto-sync job retries to spread their runtime over a longer period, hopefully decreasing load.

Any ideas?